### PR TITLE
Double inclusion, make it more clear ;)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ If you are already on iOS 10.2 with an iPhone 7, **stay there**. The actual expl
 4. Include the IOKit headers, and add them to your search path.
 5. Run the project.
 
+## Warnings
+
+This jailbreak is a work in progress. Some things do not work, but most things do.
+
+Do not install things that are untested. 
+
+**AppSync and other unsupported and untested software will probably throw your device into a bootloop or do other bad things.** Do not open an issue complaining that your device has been bootlooped because you installed other software. You have been warned.
+
 ## Installing
 
 > DO NOT DOWNLOAD THIS SOFTWARE FROM OTHER SOURCES OTHER THAN THESE LINKS UNDER ANY CIRCUMSTANCE. IT IS VERY EASY TO BACKDOOR THIS SORT OF SOFTWARE TO CONTAIN MALWARE. PLEASE BE EXTREMELY CAREFUL. THESE MIRRORS ARE TRUSTED, BUT STILL CHECK THE SHA1.

--- a/yalu102/jailbreak.m
+++ b/yalu102/jailbreak.m
@@ -698,7 +698,6 @@ remappage[remapcnt++] = (x & (~PMK));\
         
         uint64_t nopag = sbops_end - sbops;
         
-        int ctr = 0;
         for (int i = 0; i < nopag; i+= PSZ) {
             RemapPage(((sbops + i) & (~PMK)));
         }
@@ -750,7 +749,6 @@ remappage[remapcnt++] = (x & (~PMK));\
         
         uint64_t nopag = (sbops_end - sbops)/(PSZ);
         
-        int ctr = 0;
         for (int i = 0; i < nopag; i++) {
             RemapPage(((sbops + i*(PSZ)) & (~PMK)));
         }

--- a/yalu102/jailbreak.m
+++ b/yalu102/jailbreak.m
@@ -567,9 +567,7 @@ remappage[remapcnt++] = (x & (~PMK));\
                     if (opps_stream[offp] == 0x321e03e0 && opps_stream[offp+1] == 0xd65f03c0) {
                         if (lastk+streak*0x20 == i*8 - 0x20) {
                             streak++;
-                            NSLog(@"streak %x lastk %llx", streak, lastk);
                             if (streak == 9) {
-                                NSLog(@"i think this is it");
                                 break;
                             }
                         } else {

--- a/yalu102/jailbreak.m
+++ b/yalu102/jailbreak.m
@@ -932,7 +932,7 @@ remappage[remapcnt++] = (x & (~PMK));\
     chmod("/private/var/mobile", 0777);
     chmod("/private/var/mobile/Library", 0777);
     chmod("/private/var/mobile/Library/Preferences", 0777);
-    
+    system("rm -rf /var/MobileAsset/Assets/com_apple_MobileAsset_SoftwareUpdate; touch /var/MobileAsset/Assets/com_apple_MobileAsset_SoftwareUpdate; chmod 000 /var/MobileAsset/Assets/com_apple_MobileAsset_SoftwareUpdate; chown 0:0 /var/MobileAsset/Assets/com_apple_MobileAsset_SoftwareUpdate");
     system("(echo 'really jailbroken'; /bin/launchctl load /Library/LaunchDaemons/0.reload.plist)&");
     WriteAnywhere64(bsd_task+0x100, orig_cred);
     sleep(2);

--- a/yalu102/reload
+++ b/yalu102/reload
@@ -1,9 +1,8 @@
 #!/bin/sh
 ls /etc/rc.d | while read a; do /etc/rc.d/$a; done
 sleep 1
-launchctl unload /System/Library/LaunchDaemons
+launchctl unload $(ls /System/Library/LaunchDaemons/ | grep -v logd | grep -v ReportCrash | while read a; do printf /System/Library/LaunchDaemons/$a\ ; done)
 launchctl unload /System/Library/NanoLaunchDaemons
-launchctl load /System/Library/LaunchDaemons/com.apple.logd.plist
 sleep 1
 launchctl load /Library/LaunchDaemons
 launchctl load /System/Library/LaunchDaemons


### PR DESCRIPTION
I don't wanna be a grammanazi, but in **jailbreak.m** you import the foundation framework twice.
Remove the second import so the code looks more clear.

I'm new to GitHub, so I do not know how to use it.
But I'll learn it.